### PR TITLE
feat: add smooth bar animations

### DIFF
--- a/src/BrandDynamics.jsx
+++ b/src/BrandDynamics.jsx
@@ -109,7 +109,12 @@ export default function BrandDynamics() {
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis type="number" />
                 <YAxis dataKey="name" type="category" width={100} />
-                <Bar dataKey="value" isAnimationActive={false}>
+                <Bar
+                  dataKey="value"
+                  isAnimationActive
+                  animationDuration={400}
+                  animationEasing="ease-in-out"
+                >
                   {data.map((entry, index) => (
                     <Cell
                       key={`cell-${entry.name}`}

--- a/src/index.css
+++ b/src/index.css
@@ -3,3 +3,8 @@ body {
   margin: 0;
   font-family: sans-serif;
 }
+
+/* Smooth bar animations */
+.recharts-bar-rectangles rect {
+  transition: all 0.4s ease;
+}


### PR DESCRIPTION
## Summary
- enable smooth animation for bar growth and position changes on BrandDynamics
- add CSS transitions to bars for fluid reordering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6350e0c248325b829b81e76af3e68