### PR TITLE
feat: add bar chart race with sample series

### DIFF
--- a/src/BrandDynamics.jsx
+++ b/src/BrandDynamics.jsx
@@ -9,12 +9,7 @@ import {
   ResponsiveContainer,
   Cell,
 } from "recharts";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 const COLORS = [
   "#1f77b4",
@@ -29,46 +24,51 @@ const COLORS = [
   "#17becf",
 ];
 
-const INITIAL_BRANDS = [
-  { name: "Toyota", value: 0 },
-  { name: "Volkswagen", value: 0 },
-  { name: "Honda", value: 0 },
-  { name: "Ford", value: 0 },
-  { name: "Hyundai", value: 0 },
-  { name: "Nissan", value: 0 },
-  { name: "Suzuki", value: 0 },
-  { name: "Kia", value: 0 },
-  { name: "Chevrolet", value: 0 },
-  { name: "BYD", value: 0 },
+// Произвольные (выдуманные) продажи брендов по годам, тыс. авто
+const SERIES = [
+  { year: 2019, Toyota: 8500, Volkswagen: 6400, Honda: 3800, Ford: 3600, Hyundai: 3400, Nissan: 3300, Suzuki: 3000, Kia: 2900, Chevrolet: 2700, BYD: 2500 },
+  { year: 2020, Toyota: 8600, Volkswagen: 6500, Honda: 3850, Ford: 3550, Hyundai: 3450, Nissan: 3350, Suzuki: 3050, Kia: 2950, Chevrolet: 2750, BYD: 2600 },
+  { year: 2021, Toyota: 8700, Volkswagen: 6600, Honda: 3900, Ford: 3600, Hyundai: 3500, Nissan: 3400, Suzuki: 3100, Kia: 3000, Chevrolet: 2800, BYD: 2700 },
+  { year: 2022, Toyota: 8900, Volkswagen: 6700, Honda: 4000, Ford: 3650, Hyundai: 3550, Nissan: 3450, Suzuki: 3150, Kia: 3050, Chevrolet: 2850, BYD: 2800 },
+  { year: 2023, Toyota: 9100, Volkswagen: 6800, Honda: 4100, Ford: 3700, Hyundai: 3600, Nissan: 3500, Suzuki: 3200, Kia: 3100, Chevrolet: 2900, BYD: 3000 },
 ];
 
+function extractStep(step) {
+  const entry = SERIES[Math.min(step, SERIES.length - 1)];
+  const { year, ...brands } = entry;
+  const data = Object.entries(brands)
+    .map(([name, value]) => ({ name, value }))
+    .sort((a, b) => b.value - a.value);
+  return { year, data };
+}
+
 export default function BrandDynamics() {
-  const [data, setData] = useState(INITIAL_BRANDS);
-  const [year, setYear] = useState(1820);
-  const [month, setMonth] = useState(1);
+  const [step, setStep] = useState(0);
+  const { year: initialYear, data: initialData } = extractStep(0);
+  const [data, setData] = useState(initialData);
+  const [year, setYear] = useState(initialYear);
   const timerRef = useRef(null);
 
   const start = () => {
     if (timerRef.current) return;
+    setStep(0);
     timerRef.current = setInterval(() => {
-      setData((prev) => {
-        const updated = prev.map((b) => ({
-          ...b,
-          value: b.value + Math.floor(Math.random() * 1000),
-        }));
-        updated.sort((a, b) => b.value - a.value);
-        return [...updated];
-      });
-
-      setMonth((m) => {
-        if (m === 12) {
-          setYear((y) => y + 1);
-          return 1;
+      setStep((prev) => {
+        if (prev + 1 >= SERIES.length) {
+          clearInterval(timerRef.current);
+          timerRef.current = null;
+          return prev;
         }
-        return m + 1;
+        return prev + 1;
       });
-    }, 500);
+    }, 1000);
   };
+
+  useEffect(() => {
+    const { year, data } = extractStep(step);
+    setYear(year);
+    setData(data);
+  }, [step]);
 
   useEffect(() => {
     return () => clearInterval(timerRef.current);
@@ -100,9 +100,7 @@ export default function BrandDynamics() {
               >
                 Старт
               </button>
-              <div className="text-lg font-medium">
-                {year} г. {String(month).padStart(2, "0")} мес.
-              </div>
+              <div className="text-lg font-medium">{year} г.</div>
             </div>
             <ResponsiveContainer width="100%" height={500}>
               <BarChart data={data} layout="vertical" margin={{ left: 80 }}>


### PR DESCRIPTION
## Summary
- add brand sales time-series dataset
- animate bar chart race across years

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a638175d108325aaff2620a399fb6e