### PR TITLE
feat: improve brand dynamics with canvas race

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <title>Car Stats</title>
     <!-- Include Tailwind CSS from CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-race"></script>
     <style>
       <!--      table { border-collapse: collapse; }
       <!--      table, table th, table td { border: 1px solid rgba(0, 0, 0, 0.08); }


### PR DESCRIPTION
## Summary
- replace Recharts race chart with canvas-based Chart.js implementation for smoother bar growth animation
- load Chart.js and chartjs-chart-race via CDN

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7589e68f48325a86b4195d68e9ac8