### PR TITLE
Add smooth bar animation with counters

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <!-- Include Tailwind CSS from CDN for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-race"></script>
     <style>
       <!--      table { border-collapse: collapse; }

--- a/src/BrandDynamics.jsx
+++ b/src/BrandDynamics.jsx
@@ -76,6 +76,7 @@ export default function BrandDynamics() {
   useEffect(() => {
     const ctx = canvasRef.current?.getContext("2d");
     if (!ctx) return;
+    window.Chart.register(window.ChartDataLabels);
     chartRef.current = new window.Chart(ctx, {
       type: "bar",
       data: {
@@ -92,11 +93,20 @@ export default function BrandDynamics() {
         responsive: true,
         maintainAspectRatio: false,
         animation: {
-          duration: 800,
-          easing: "easeOutQuart",
+          duration: 1000,
+          easing: "linear",
         },
         plugins: {
           legend: { display: false },
+          datalabels: {
+            anchor: "end",
+            align: "right",
+            formatter: (_, ctx) => {
+              const meta = ctx.chart.getDatasetMeta(0).data[ctx.dataIndex];
+              const value = ctx.chart.scales.x.getValueForPixel(meta.x);
+              return Math.round(value);
+            },
+          },
         },
         scales: {
           x: { beginAtZero: true },


### PR DESCRIPTION
## Summary
- Include Chart.js data labels plugin
- Animate brand race bars at a constant speed with live counters

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a75a8c57088325a3ac4bcc823e1d5c