### PR TITLE
Fix missing bar when brand re-enters ranking

### DIFF
--- a/src/BrandDynamics.jsx
+++ b/src/BrandDynamics.jsx
@@ -165,6 +165,7 @@ export default function BrandDynamics() {
                 .remove()
             )
         )
+        .attr("height", y.bandwidth())
         .transition(t)
         .attr("width", (d) => x(d.value))
         .attr("y", (d) => y(d.rank));


### PR DESCRIPTION
## Summary
- ensure bar heights are reapplied each update so returning brands render correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a76b76c8f88325a48c140eb046b46b